### PR TITLE
Removed trailing slash from BaseURLv1

### DIFF
--- a/pkg/sms/client.go
+++ b/pkg/sms/client.go
@@ -16,7 +16,7 @@ type client struct {
 }
 
 const (
-	BaseURLv1   = ".sms.api.sinch.com/xms/v1/"
+	BaseURLv1   = ".sms.api.sinch.com/xms/v1"
 	USBaseURLv1 = "https://us" + BaseURLv1
 	EUBaseURLv1 = "https://eu" + BaseURLv1
 	AUBaseURLv1 = "https://au" + BaseURLv1


### PR DESCRIPTION
Where this Base url is used it gets a slash appended to it along with following information causing a // to appear in the sendURL when the toRequest function is called