### PR TITLE
Fix Availability Validate() Function

### DIFF
--- a/pkg/numbers/availability.go
+++ b/pkg/numbers/availability.go
@@ -7,6 +7,7 @@ import (
 	"github.com/biter777/countries"
 	"github.com/google/go-querystring/query"
 	"github.com/thezmc/go-sinch/pkg/sinch"
+	"go.uber.org/multierr"
 )
 
 type AvailabilityAction struct {
@@ -148,7 +149,10 @@ func (ac *AvailabilityRequest) Validate() error {
 	if ac.Type == "" {
 		errs = append(errs, TypeRequiredError)
 	}
-	return errs
+	if len(errs) > 0 {
+		return multierr.Combine(errs)
+	}
+	return nil
 }
 
 func (ac *AvailabilityRequest) ExpectedStatusCode() int {


### PR DESCRIPTION
There was a bug in how errors were returned from the `Validate()` function within the `availability` package. By joining all errors within the `errs` object into a single error to return (or `nil` if the `errs` object is empty), this bug should be resolved.

Makes use of the Uber `multierr` package, which was already in use within this repo.