### PR TITLE
update: add active virtual number update

### DIFF
--- a/pkg/numbers/activation.go
+++ b/pkg/numbers/activation.go
@@ -18,15 +18,6 @@ type ActivationRequest struct {
 	VoiceConfiguration *RequestVoiceConfiguration `url:"-" json:"voiceConfiguration,omitempty"`
 }
 
-type RequestSMSConfiguration struct {
-	ServicePlanID string `json:"servicePlanId"` // required
-	CampaignID    string `json:"campaignId"`
-}
-
-type RequestVoiceConfiguration struct {
-	AppID string `json:"appId"`
-}
-
 type ActivationResponse struct {
 	PhoneNumber           string                      `json:"phoneNumber"`
 	ProjectID             string                      `json:"projectId"`
@@ -40,31 +31,6 @@ type ActivationResponse struct {
 	ExpireAt              string                      `json:"expireAt"`
 	SMSConfiguration      *ResponseSMSConfiguration   `json:"smsConfiguration"`
 	VoiceConfiguration    *ResponseVoiceConfiguration `json:"voiceConfiguration,omitempty"`
-	LastUpdatedTime       string                      `json:"lastUpdatedTime"`
-}
-
-type ResponseSMSConfiguration struct {
-	ServicePlanID         string                         `json:"servicePlanId"` // required
-	ScheduledProvisioning *ResponseScheduledProvisioning `json:"scheduledProvisioning"`
-}
-
-type ResponseScheduledProvisioning struct {
-	ServicePlanID   string   `json:"servicePlanId"`
-	Status          string   `json:"status"`
-	LastUpdatedTime string   `json:"lastUpdatedTime"`
-	CampaignID      string   `json:"campaignId"`
-	ErrorCodes      []string `json:"errorCodes"`
-}
-
-type ResponseVoiceConfiguration struct {
-	AppID                      string                              `json:"appId"`
-	ScheduledVoiceProvisioning *ResponseScheduledVoiceProvisioning `json:"scheduledVoiceProvisioning"`
-}
-
-type ResponseScheduledVoiceProvisioning struct {
-	AppID           string `json:"appId"`
-	Status          string `json:"status"`
-	LastUpdatedTime string `json:"lastUpdatedTime"`
 }
 
 func (a *Activation) IsNumbersAction() {}
@@ -92,7 +58,7 @@ func (ar *ActivationRequest) WithPhoneNumber(phoneNumber string) *ActivationRequ
 	return ar
 }
 
-func (ar *ActivationRequest) WithSMSConfiguration(servicePlanID, campaignID string) *ActivationRequest {
+func (ar *ActivationRequest) WithSMSConfiguration(servicePlanID string, campaignID string) *ActivationRequest {
 	if ar.SMSConfiguration == nil {
 		ar.SMSConfiguration = new(RequestSMSConfiguration)
 	}

--- a/pkg/numbers/types.go
+++ b/pkg/numbers/types.go
@@ -1,0 +1,36 @@
+package numbers
+
+type RequestSMSConfiguration struct {
+	ServicePlanID string `json:"servicePlanId"` // required
+	CampaignID    string `json:"campaignId"`
+}
+
+type RequestVoiceConfiguration struct {
+	AppID string `json:"appId"`
+}
+
+type ResponseSMSConfiguration struct {
+	ServicePlanID         string                         `json:"servicePlanId"` // required
+	ScheduledProvisioning *ResponseScheduledProvisioning `json:"scheduledProvisioning"`
+	CampaignID            string                         `json:"campaignId"`
+}
+
+type ResponseScheduledProvisioning struct {
+	ServicePlanID   string   `json:"servicePlanId"`
+	Status          string   `json:"status"`
+	LastUpdatedTime string   `json:"lastUpdatedTime"`
+	CampaignID      string   `json:"campaignId"`
+	ErrorCodes      []string `json:"errorCodes"`
+}
+
+type ResponseVoiceConfiguration struct {
+	AppID                      string                              `json:"appId"`
+	ScheduledVoiceProvisioning *ResponseScheduledVoiceProvisioning `json:"scheduledVoiceProvisioning"`
+	LastUpdatedTime            string                              `json:"lastUpdatedTime"`
+}
+
+type ResponseScheduledVoiceProvisioning struct {
+	AppID           string `json:"appId"`
+	Status          string `json:"status"`
+	LastUpdatedTime string `json:"lastUpdatedTime"`
+}

--- a/pkg/numbers/update.go
+++ b/pkg/numbers/update.go
@@ -1,0 +1,140 @@
+package numbers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/thezmc/go-sinch/pkg/sinch"
+)
+
+type Update struct {
+	request  *UpdateRequest
+	response *UpdateResponse
+}
+
+type UpdateRequest struct {
+	PhoneNumber        string                     `url:"phoneNumber" json:"-"`
+	DisplayName        string                     `url:"-" json:"displayName,omitempty"`
+	SMSConfiguration   *RequestSMSConfiguration   `url:"-" json:"smsConfiguration,omitempty"`
+	VoiceConfiguration *RequestVoiceConfiguration `url:"-" json:"voiceConfiguration,omitempty"`
+}
+
+type UpdateResponse struct {
+	PhoneNumber           string                      `json:"phoneNumber"`
+	ProjectId             string                      `json:"projectId"`
+	DisplayName           string                      `json:"displayName"`
+	RegionCode            string                      `json:"regionCode"`
+	Type                  string                      `json:"type"`
+	Capability            []string                    `json:"capability"`
+	Money                 Price                       `json:"money"`
+	PaymentIntervalMonths int                         `json:"paymentIntervalMonths"`
+	NextChargeDate        string                      `json:"nextChargeDate"`
+	ExpireAt              string                      `json:"expireAt"`
+	SMSConfiguration      *ResponseSMSConfiguration   `json:"smsConfiguration"`
+	VoiceConfiguration    *ResponseVoiceConfiguration `json:"voiceConfiguration,omitempty"`
+}
+
+func (u *Update) IsNumbersAction() {}
+
+func (u *Update) WithRequest(request *UpdateRequest) *Update {
+	u.request = request
+	return u
+}
+
+func (u *Update) WithResponse(response *UpdateResponse) *Update {
+	u.response = response
+	return u
+}
+
+func (u *Update) Request() *UpdateRequest {
+	return u.request
+}
+
+func (u *Update) Response() *UpdateResponse {
+	return u.response
+}
+
+func (ur *UpdateRequest) WithPhoneNumber(phoneNumber string) *UpdateRequest {
+	ur.PhoneNumber = phoneNumber
+	return ur
+}
+
+func (ur *UpdateRequest) WithDisplayName(displayName string) *UpdateRequest {
+	ur.DisplayName = displayName
+	return ur
+}
+
+func (ur *UpdateRequest) WithSMSConfiguration(smsConfiguration *RequestSMSConfiguration) *UpdateRequest {
+	ur.SMSConfiguration = smsConfiguration
+	return ur
+}
+
+func (ur *UpdateRequest) WithVoiceConfiguration(voiceConfiguration *RequestVoiceConfiguration) *UpdateRequest {
+	ur.VoiceConfiguration = voiceConfiguration
+	return ur
+}
+
+func (ur *UpdateRequest) WithSMSConfigurationServicePlanID(servicePlanID string) *UpdateRequest {
+	if ur.SMSConfiguration == nil {
+		ur.SMSConfiguration = new(RequestSMSConfiguration)
+	}
+	ur.SMSConfiguration.ServicePlanID = servicePlanID
+	return ur
+}
+
+func (ur *UpdateRequest) WithSMSConfigurationCampaignID(campaignID string) *UpdateRequest {
+	if ur.SMSConfiguration == nil {
+		ur.SMSConfiguration = new(RequestSMSConfiguration)
+	}
+	ur.SMSConfiguration.CampaignID = campaignID
+	return ur
+}
+
+func (ur *UpdateRequest) WithVoiceConfigurationAppID(appID string) *UpdateRequest {
+	if ur.VoiceConfiguration == nil {
+		ur.VoiceConfiguration = new(RequestVoiceConfiguration)
+	}
+	ur.VoiceConfiguration.AppID = appID
+	return ur
+}
+
+func (ur *UpdateRequest) Validate() error {
+	var errors sinch.Errors
+	if ur.PhoneNumber == "" {
+		errors = append(errors, PhoneNumberRequiredError)
+	}
+
+	if ur.SMSConfiguration != nil {
+		if ur.SMSConfiguration.ServicePlanID == "" {
+			errors = append(errors, ServicePlanIDRequiredError)
+		}
+	}
+	if len(errors) > 0 {
+		return errors
+	}
+	return nil
+}
+
+func (ur *UpdateRequest) Body() ([]byte, error) {
+	return json.Marshal(ur)
+}
+
+func (ur *UpdateRequest) Method() string {
+	return http.MethodPatch
+}
+
+func (ur *UpdateRequest) Path() string {
+	return "/activeNumbers/" + ur.PhoneNumber
+}
+
+func (ur *UpdateRequest) QueryString() (string, error) {
+	return "", nil
+}
+
+func (ur *UpdateRequest) ExpectedStatusCode() int {
+	return http.StatusOK
+}
+
+func (ur *UpdateResponse) FromJSON(bytes []byte) error {
+	return json.Unmarshal(bytes, ur)
+}

--- a/pkg/numbers/update_test.go
+++ b/pkg/numbers/update_test.go
@@ -1,0 +1,135 @@
+package numbers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thezmc/go-sinch/pkg/sinch"
+)
+
+func Test_Update_Implementations(t *testing.T) {
+	var _ sinch.Action[*UpdateRequest, *UpdateResponse] = new(Update)
+	var _ sinch.APIRequest = new(UpdateRequest)
+	var _ sinch.APIResponse = new(UpdateResponse)
+}
+
+func Test_UpdateRequest_Validate(t *testing.T) {
+	ur := new(UpdateRequest)
+
+	tests := map[string]struct {
+		configFn    func()
+		expectedErr error
+	}{
+		"missing number": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("")
+			},
+			expectedErr: PhoneNumberRequiredError,
+		},
+		"missing configuation": {
+			configFn: func() {
+				ur = new(UpdateRequest)
+			},
+			expectedErr: MissingConfigurationError,
+		},
+		"missing service plan": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithSMSConfiguration(&RequestSMSConfiguration{ServicePlanID: ""})
+			},
+			expectedErr: ServicePlanIDRequiredError,
+		},
+		"with request": {
+			configFn: func() {
+				u := new(Update).WithRequest(new(UpdateRequest).WithPhoneNumber("1234567890"))
+				ur = u.Request()
+			},
+		},
+		"with response": {
+			configFn: func() {
+				u := new(Update).WithResponse(new(UpdateResponse))
+				ur = u.Request()
+			},
+		},
+		"with display name": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithDisplayName("test")
+			},
+			expectedErr: nil,
+		},
+		"with voice configuration": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithVoiceConfiguration(&RequestVoiceConfiguration{AppID: "test"})
+			},
+			expectedErr: nil,
+		},
+		"with sms configuration service plan id": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithSMSConfigurationServicePlanID("test")
+			},
+			expectedErr: nil,
+		},
+		"with sms configuration campaign id": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithSMSConfigurationCampaignID("test")
+			},
+			expectedErr: nil,
+		},
+		"with voice configuration app id": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithVoiceConfigurationAppID("test")
+			},
+			expectedErr: nil,
+		},
+		"get update request body": {
+			configFn: func() {
+				_, err := new(UpdateRequest).WithPhoneNumber("1234567890").WithDisplayName("test").WithSMSConfiguration(&RequestSMSConfiguration{ServicePlanID: "test"}).WithVoiceConfiguration(&RequestVoiceConfiguration{AppID: "test"}).Body()
+				assert.NoError(t, err)
+			},
+		},
+		"get method type": {
+			configFn: func() {
+				assert.Equal(t, http.MethodPatch, new(UpdateRequest).Method())
+			},
+		},
+		"get path": {
+			configFn: func() {
+				assert.Equal(t, "/activeNumbers/1234567890", new(UpdateRequest).Path())
+			},
+		},
+		"get expected status code": {
+			configFn: func() {
+				assert.Equal(t, http.StatusOK, new(UpdateRequest).ExpectedStatusCode())
+			},
+		},
+		"get query string": {
+			configFn: func() {
+				_, err := new(UpdateRequest).QueryString()
+				assert.NoError(t, err)
+			},
+		},
+		"get response from json": {
+			configFn: func() {
+				err := new(UpdateResponse).FromJSON([]byte(`{"phoneNumber": "1234567890"}`))
+				assert.NoError(t, err)
+			},
+		},
+		"no errors": {
+			configFn: func() {
+				ur = new(UpdateRequest).WithPhoneNumber("1234567890").WithSMSConfiguration(&RequestSMSConfiguration{ServicePlanID: "test"})
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.configFn()
+			if test.expectedErr != nil {
+				assert.ErrorContains(t, ur.Validate(), test.expectedErr.Error())
+			} else {
+				assert.NoError(t, ur.Validate())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sinch has an activate new virtual number and an update active virtual number endpoint. The former is under the Available Number section and the later is under the Active Number section of their Numbers API documentation. Not sure if "update" was the right filename to go with but I just picked something so lmk if you think I should change it. 

Added an interface for this sinch endpoint: https://developers.sinch.com/docs/numbers/api-reference/numbers/tag/Active-Number/#tag/Active-Number/operation/NumberService_UpdateActiveNumber